### PR TITLE
IndexOutOfBounds fix

### DIFF
--- a/src/test/java/make/some/noise/SuperSimplexNoise.java
+++ b/src/test/java/make/some/noise/SuperSimplexNoise.java
@@ -49,8 +49,8 @@ public class SuperSimplexNoise {
 			if (r < 0)
 				r += (i + 1);
 			perm[i] = source[r];
-			permGrad2[i] = GRADIENTS_2D[perm[i]];
-			permGrad3[i] = GRADIENTS_3D[perm[i]];
+			permGrad2[i] = GRADIENTS_2D[perm[i] %GRADIENTS_2D.length];
+			permGrad3[i] = GRADIENTS_3D[perm[i] %GRADIENTS_3D.length];
 			source[r] = source[i];
 		}
 	}


### PR DESCRIPTION
I looked for main methods in the IDE and ran those four, and this one hit an IndexOutOfBounds exception every time. I honestly don't understand how the algorithm works, but I put the %/rem operator in there so the index would just wrap around and stay within bounds. Demo runs now.